### PR TITLE
Add serializable protocol

### DIFF
--- a/lib/casex.ex
+++ b/lib/casex.ex
@@ -33,6 +33,8 @@ defmodule Casex do
   Now all outcoming json response bodies will be converted to camel case.
   """
 
+  alias Casex.Serializable
+
   @doc """
   Converts all keys of a map to snake case.
   If the map is a struct with no `Enumerable` implementation the value is returned without convertion.
@@ -119,6 +121,7 @@ defmodule Casex do
   @spec to_camel_case(data :: term()) :: term()
   def to_camel_case(data) when is_map(data) do
     data
+    |> Serializable.serialize()
     |> Enum.map(fn {key, value} -> {camel_case(key), to_camel_case(value)} end)
     |> Enum.into(%{})
   rescue
@@ -129,7 +132,7 @@ defmodule Casex do
     Enum.map(data, &to_camel_case/1)
   end
 
-  def to_camel_case(data), do: data
+  def to_camel_case(data), do: Serializable.serialize(data)
 
   defp camel_case(value) when is_atom(value) do
     value

--- a/lib/casex/camel_case_encoder.ex
+++ b/lib/casex/camel_case_encoder.ex
@@ -12,6 +12,13 @@ defmodule Casex.CamelCaseEncoder do
   ```
 
   Now all outcoming json response bodies will be converted to camel case.
+
+  ## Structs
+
+  If you want to control how the keys will be serilized before been encoded by `Jason`,
+  you can provide a implementation for the `Casex.Serializable` protocol, by default it
+  will return the structs as they come, without any transformation.
+
   """
 
   @spec encode_to_iodata!(data :: term()) :: iodata() | no_return()

--- a/lib/casex/camel_case_encoder.ex
+++ b/lib/casex/camel_case_encoder.ex
@@ -15,7 +15,7 @@ defmodule Casex.CamelCaseEncoder do
 
   ## Structs
 
-  If you want to control how the keys will be serilized before been encoded by `Jason`,
+  If you want to control how the keys will be serilized before being encoded by `Jason`,
   you can provide a implementation for the `Casex.Serializable` protocol, by default it
   will return the structs as they come, without any transformation.
 

--- a/lib/casex/serializable.ex
+++ b/lib/casex/serializable.ex
@@ -1,0 +1,85 @@
+defprotocol Casex.Serializable do
+  @moduledoc """
+  Protocol controlling how a value is serialized. It is useful to handle custom
+  structs of your app, without that the `Casex` will be skipped and passed directly to Jason.
+
+  ## Deriving
+
+  The protocol allows leveraging the Elixir's `@derive` feature
+  to simplify protocol implementation in trivial cases. Accepted
+  options are:
+
+    * `:only` - encodes only values of specified keys.
+    * `:except` - encodes all struct fields except specified keys.
+
+  By default all keys except the `:__struct__` key are serialized.
+
+  ## Example
+
+  Let's assume a presence of the following struct:
+
+      defmodule Test do
+        defstruct [:foo, :bar, :baz]
+      end
+
+  If we were to call `@derive Casex.Serializable` just before `defstruct`,
+  an implementation similar to the following implementation would be generated:
+
+      defimpl Casex.Serializable, for: Test do
+        def serialize(data) do
+          Map.take(data, [:foo, :bar, :baz])
+        end
+      end
+
+  If we called `@derive {Casex.Serializable, only: [:foo]}`, an implementation
+  similar to the following implementation would be generated:
+
+      defimpl Casex.Serializable, for: Test do
+        def serialize(data) do
+          Map.take(data, [:foo])
+        end
+      end
+
+  If we called `@derive {Casex.Serializable, except: [:foo]}`, an implementation
+  similar to the following implementation would be generated:
+
+      defimpl Casex.Serializable, for: Test do
+        def serialize(data) do
+          Map.take(data, [:bar, :baz])
+        end
+      end
+
+  """
+
+  @fallback_to_any true
+  def serialize(data)
+end
+
+defimpl Casex.Serializable, for: Any do
+  defmacro __deriving__(module, struct, options) do
+    fields = fields_to_encode(struct, options)
+
+    quote do
+      defimpl Casex.Serializable, for: unquote(module) do
+        def serialize(data) do
+          Map.take(data, unquote(fields))
+        end
+      end
+    end
+  end
+
+  def serialize(data), do: data
+
+  defp fields_to_encode(struct, opts) do
+    cond do
+      only = Keyword.get(opts, :only) ->
+        only
+
+      except = Keyword.get(opts, :except) ->
+        Map.keys(struct) -- [:__struct__ | except]
+
+      true ->
+        Map.keys(struct) -- [:__struct__]
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -8,6 +8,7 @@ defmodule Casex.MixProject do
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
+      elixirc_paths: elixirc_paths(Mix.env()),
       description: "Simple case conversion for web applications",
       package: package(),
       name: "Casex",
@@ -21,6 +22,9 @@ defmodule Casex.MixProject do
       extra_applications: [:logger]
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do

--- a/test/casex_test.exs
+++ b/test/casex_test.exs
@@ -1,10 +1,15 @@
 defmodule CasexTest do
-  use ExUnit.Case
-  doctest Casex
+  use ExUnit.Case, async: true
 
-  defmodule MyStruct do
-    defstruct [:key]
-  end
+  alias Casex.{
+    MyStruct,
+    MyStructDerived,
+    MyStructDerivedWithOnly,
+    MyStructDerivedWithExcept,
+    MySerializableStruct
+  }
+
+  doctest Casex
 
   test "README install version check" do
     app = :casex
@@ -18,15 +23,39 @@ defmodule CasexTest do
 
   describe "to_camel_case/1" do
     test "struct" do
-      my_struct = %MyStruct{key: "value"}
+      my_struct = %MyStruct{cool_key: "value"}
 
       assert Casex.to_camel_case(my_struct) == my_struct
+    end
+
+    test "seriazable struct" do
+      my_struct = %MySerializableStruct{cool_key: "value"}
+
+      assert Casex.to_camel_case(my_struct) == %{"coolKey" => "value"}
+    end
+
+    test "derived struct" do
+      my_struct = %MyStructDerived{cool_key: "value", another_key: "another"}
+
+      assert Casex.to_camel_case(my_struct) == %{"coolKey" => "value", "anotherKey" => "another"}
+    end
+
+    test "derived struct with only" do
+      my_struct = %MyStructDerivedWithOnly{cool_key: "value", another_key: "another"}
+
+      assert Casex.to_camel_case(my_struct) == %{"coolKey" => "value"}
+    end
+
+    test "derived struct with except" do
+      my_struct = %MyStructDerivedWithExcept{cool_key: "value", another_key: "another"}
+
+      assert Casex.to_camel_case(my_struct) == %{"anotherKey" => "another"}
     end
   end
 
   describe "to_snake_case/1" do
     test "struct" do
-      my_struct = %MyStruct{key: "value"}
+      my_struct = %MyStruct{cool_key: "value"}
 
       assert Casex.to_snake_case(my_struct) == my_struct
     end

--- a/test/support/structs.ex
+++ b/test/support/structs.ex
@@ -1,0 +1,29 @@
+defmodule Casex.MySerializableStruct do
+  defstruct [:cool_key]
+
+  defimpl Casex.Serializable do
+    def serialize(data), do: Map.take(data, [:cool_key])
+  end
+end
+
+defmodule Casex.MyStruct do
+  defstruct [:cool_key]
+end
+
+defmodule Casex.MyStructDerived do
+  @derive Casex.Serializable
+
+  defstruct [:cool_key, :another_key]
+end
+
+defmodule Casex.MyStructDerivedWithOnly do
+  @derive {Casex.Serializable, only: [:cool_key]}
+
+  defstruct [:cool_key, :another_key]
+end
+
+defmodule Casex.MyStructDerivedWithExcept do
+  @derive {Casex.Serializable, except: [:cool_key]}
+
+  defstruct [:cool_key, :another_key]
+end


### PR DESCRIPTION
## Motivation

We need a way to convert structs to simples values as string or maps so it can converted to camelCase as well.

## Proposed solution

Add `Casex.Serializable` protocol where we can control how the values will be serialized before converting the keys to camel case.