### PR TITLE
Optimize at compile time the case conversions

### DIFF
--- a/lib/casex.ex
+++ b/lib/casex.ex
@@ -120,10 +120,21 @@ defmodule Casex do
   """
   @spec to_camel_case(data :: term()) :: term()
   def to_camel_case(data) when is_map(data) do
-    data
-    |> Serializable.serialize()
-    |> Enum.map(fn {key, value} -> {camel_case(key), to_camel_case(value)} end)
-    |> Enum.into(%{})
+    result = Serializable.serialize(data)
+
+    case result do
+      {map, dict} ->
+        map
+        |> Enum.map(fn {key, value} ->
+          {Map.get_lazy(dict, key, fn -> camel_case(key) end), to_camel_case(value)}
+        end)
+        |> Enum.into(%{})
+
+      map ->
+        map
+        |> Enum.map(fn {key, value} -> {camel_case(key), to_camel_case(value)} end)
+        |> Enum.into(%{})
+    end
   rescue
     Protocol.UndefinedError -> data
   end


### PR DESCRIPTION
## Motivation

In some cases, when the map is too big the conversion can become slow.

## Proposed solution

Perform the case conversion at compile time in the default implementation for the serializable protocol.